### PR TITLE
A few changes to build as dynamic lib and support 64bit better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+/lib
+/obj

--- a/Alc/alcandroid.c
+++ b/Alc/alcandroid.c
@@ -12,6 +12,20 @@ JavaVM *alcGetJavaVM(void) {
 	return javaVM;
 }
 
+void alcandroid_OnLoad( JavaVM *vm ) {
+	BackendFuncs func_list;
+	if (apportableOpenALFuncs.alc_android_set_java_vm) {
+		apportableOpenALFuncs.alc_android_set_java_vm(vm);
+	}
+	javaVM = vm;
+}
+
+void alcandroid_OnUnload( JavaVM *vm ) {
+	if (apportableOpenALFuncs.alc_android_set_java_vm) {
+		apportableOpenALFuncs.alc_android_set_java_vm(NULL);
+	}
+}
+
 	//when called as a shared lib, this is automatic
 	//but when embedding it that will be an error
 #ifdef NATIVE_TOOLKIT_OPENAL_ANDROID_SHARED
@@ -27,29 +41,14 @@ JavaVM *alcGetJavaVM(void) {
 
 #endif //NATIVE_TOOLKIT_OPENAL_ANDROID_SHARED
 
-
-void alcandroid_OnLoad( JavaVM *vm ) {
-	BackendFuncs func_list;
-	if (apportableOpenALFuncs.alc_android_set_java_vm) {
-		apportableOpenALFuncs.alc_android_set_java_vm(vm);
-	}
-	javaVM = vm;
-}
-
-void alcandroid_OnUnload( JavaVM *vm ) {
-	if (apportableOpenALFuncs.alc_android_set_java_vm) {
-		apportableOpenALFuncs.alc_android_set_java_vm(NULL);
-	}
-}
-
-void alcandroid_Suspend() {
+__attribute__((visibility("protected"))) void alcandroid_Suspend() {
 	LOGV("openal suspend");
 	if (apportableOpenALFuncs.alc_android_suspend) {
 		apportableOpenALFuncs.alc_android_suspend();
 	}
 }
 
-void alcandroid_Resume() {
+__attribute__((visibility("protected"))) void alcandroid_Resume() {
 	LOGV("openal resume");
 	if (apportableOpenALFuncs.alc_android_resume) {
 		apportableOpenALFuncs.alc_android_resume();

--- a/build-shared.sh
+++ b/build-shared.sh
@@ -1,0 +1,5 @@
+rm -rf obj
+haxelib run hxcpp library.xml -Dandroid
+haxelib run hxcpp library.xml -Dandroid -DHXCPP_ARMV7
+haxelib run hxcpp library.xml -Dandroid -DHXCPP_ARM64
+haxelib run hxcpp library.xml -Dandroid -DHXCPP_X86

--- a/files.xml
+++ b/files.xml
@@ -9,6 +9,7 @@
             <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/openal-android/OpenAL32/include/"/>
             <compilerflag value="-DAL_LIBTYPE_STATIC" if="native_toolkit_openal_static" />
             <compilerflag value="-DAL_ALEXT_PROTOTYPES" />
+            <compilerflag value="-DNATIVE_TOOLKIT_OPENAL_ANDROID_SHARED" unless="native_toolkit_openal_static"/>
 
             <file name="${NATIVE_TOOLKIT_PATH}/openal-android/Alc/ALc.c"/>
             <file name="${NATIVE_TOOLKIT_PATH}/openal-android/Alc/ALu.c"/>

--- a/include/config.h
+++ b/include/config.h
@@ -6,7 +6,6 @@
 
 #define AL_BUILD_LIBRARY
 #define HAVE_GCC_VISIBILITY
-#define NATIVE_TOOLKIT_OPENAL_ANDROID_SHARED
 
 /* Define if we have the Android backend */
 #if defined(ANDROID)

--- a/include/config.h
+++ b/include/config.h
@@ -91,6 +91,27 @@
 /* Define if we have the __int64 type */
 /* #cmakedefine HAVE___INT64 */
 
+#ifdef HXCPP_ARM64
+
+	/* Define to the size of a void pointer type */
+	#define SIZEOF_VOIDP 8
+
+#else
+
+	#ifdef HXCPP_X86_64
+
+		/* Define to the size of a void pointer type */
+		#define SIZEOF_VOIDP 8
+
+	#else
+
+		/* Define to the size of a void pointer type */
+		#define SIZEOF_VOIDP 4
+
+	#endif
+
+#endif
+
 /* Define to the size of a long int type */
 #define SIZEOF_LONG 4
 
@@ -99,9 +120,6 @@
 
 /* Define to the size of an unsigned int type */
 #define SIZEOF_UINT 4
-
-/* Define to the size of a void pointer type */
-#define SIZEOF_VOIDP 4
 
 /* Define if we have GCC's destructor attribute */
 #define HAVE_GCC_DESTRUCTOR 1

--- a/include/config.h
+++ b/include/config.h
@@ -5,6 +5,8 @@
 #define ALSOFT_VERSION "1.12.854"
 
 #define AL_BUILD_LIBRARY
+#define HAVE_GCC_VISIBILITY
+#define NATIVE_TOOLKIT_OPENAL_ANDROID_SHARED
 
 /* Define if we have the Android backend */
 #if defined(ANDROID)

--- a/library.xml
+++ b/library.xml
@@ -35,6 +35,7 @@
 
             <!-- linker flags -->
         <lib name="-lOpenSLES" unless="native_toolkit_openal_static"/>
+        <flag value="-Wl,-soname,libopenal.so" />
 
     </target>
 


### PR DESCRIPTION
I have been using a fork of openal-android for a while because I needed to make a few changes in it:

- Be able to build openal as a dynamic library which is not merged with the rest of the app binary and improve compliance with LGPL license. The library can still be linked statically with `-D static_link` like before. I have been using openal without issues this way (as a linc_library, but `libopenal.so` linked separately) for many months now, so I consider it working.

- Patch configuration (`include/config.h`) when targeting arm64 and x86_64 because previous configuration was expected to work only on 32bit targets (so far, even though it seems that this implementation of openal was not optimized for 64bit, it does seem to work fine in my tests with the config change). Didn't test on x86_64 yet, but result should be similar to arm64.

These changes could be useful for everyone, so here is my PR.